### PR TITLE
Fix rrule creation: use name= and value= for more correct syntax.

### DIFF
--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -67,8 +67,10 @@ def event_from_yaml(event_yaml: dict) -> ics.Event:
         rrule_dtstart = [line for line in rrule_lines if line.startswith('DTSTART')][0]
         rrule_dtstart = rrule_dtstart + 'Z'
         rrule_rrule = [line for line in rrule_lines if line.startswith('RRULE')][0]
-
-        event.extra.append(ics.ContentLine(rrule_rrule))
+        event.extra.append(ics.ContentLine(
+            name=rrule_rrule.split(':', 1)[0],
+            value=rrule_rrule.split(':', 1)[1],
+            ))
 
     event.dtstamp = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
     return event


### PR DESCRIPTION
- When trying to make the rrule, I was getting import errors in
  Thunderbird locally, + the online icalendar verifier.  (These
  changes have not yet been tested for the online calendars.  I also
  wondered if the online calendars would be more relaxed in parsing
  it, so that it would work).

- The rrule had a trailing ':', since it was parsed as NAME:VALUE with
  all of the rrule in NAME only, leaving the ':' on the end.

- Now, split the rrule on ':' (maxsplit=1), and make the
  ics.ContentLine with the 'name=[left side]', 'value=[right side]'.
  This leaves the colon in the right place.

- This makes the generated ics pass the validator and work locally in
  Thunderbird.  If it doesn't work with online calendars, I will
  update this PR with that information.

- Review: worth someone looking to see if this is reasonable, but I
  think there is little chance of anything being made worse than it
  was before.
