### PR TITLE
Don't set end=None for recurring events

### DIFF
--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -55,7 +55,8 @@ def event_from_yaml(event_yaml: dict) -> ics.Event:
             print('Error: must specify end date for repeating events', file=sys.stderr)
             sys.exit(-1)
 
-        event.end = d.get('end', None)
+        # This causes zero-length events, I guess overriding whatever duration might have been specified.
+        #event.end = d.get('end', None)
 
         rrule = dateutil.rrule.rrule(
             freq=interval_type[interval_measure],


### PR DESCRIPTION
- This seems to make the events be zero-length, which is probably not
  intended.  At least with duration=, recurring events work as
  expected with this change.

- Review: someone who knows more about ics and why this was made this
  way should take a look.
