### PR TITLE
Add per-calendar default timezone (in meta header)

### DIFF
--- a/example/test_calendar.yaml
+++ b/example/test_calendar.yaml
@@ -1,12 +1,15 @@
+meta:
+  tz: America/Los_Angeles
+
 events:
   - summary: Event of the Century
-    begin: 2021-09-21 15:00:00 -07:00
-    end: 2021-09-21 15:30:00 -07:00
+    begin: 2021-09-21 15:00:00
+    end: 2021-09-21 15:30:00
     description: |
       Meet the team on the northern side of the field.
 
   - summary: Half-an-hour meeting
-    begin: 2021-09-23 15:00:00
+    begin: 2021-09-23 15:00:00 -07:00
     duration:
       minutes: 30
     location: |

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import textwrap
 
@@ -28,3 +29,39 @@ def test_calendar_event():
     assert cal_str.startswith('BEGIN:VCALENDAR')
     assert 'SUMMARY:Earth Day' in cal_str
     assert cal_str.endswith('END:VCALENDAR')
+
+def test_calendar_default_timezone():
+    cal = files_to_calendar(
+        [io.StringIO(textwrap.dedent(
+            '''
+            meta:
+              tz: Europe/Helsinki
+
+            events:
+              - summary: New year's day
+                begin: 2022-01-01 00:00:00
+                duration: {hours: 1}
+
+              - summary: February 1
+                begin: 2022-02-01 00:00:00 +02:00
+                duration: {hours: 1}
+            '''
+        ))]
+    )
+    cal_str = cal.serialize()
+    assert cal_str.startswith('BEGIN:VCALENDAR')
+    assert 'SUMMARY:New year' in cal_str
+    # It is possible that the ics-py TZID string changes, but hopefully this
+    # substring is fairly safe to test against.
+    assert 'Europe/Helsinki:20220101T000000' in cal_str
+    # Second event: explicit UTC offset specified.
+    assert '"UTC+02:00":20220201T000000' in cal_str
+    assert cal_str.endswith('END:VCALENDAR')
+
+    # Test again by normalizing to UTC.  Helsinki is two hours ahead, so the
+    # times should be 22:00:00.
+    cal.normalize(datetime.timezone.utc)
+    cal_norm_str = cal.serialize()
+    # 1 Feb midnight
+    assert 'DTSTART:20211231T220000Z' # 1 jan
+    assert 'DTSTART:20220131T220000Z' # 1 feb


### PR DESCRIPTION
- A 'meta' dict at the top level can be used to specific metadata: in
  this case 'tz', in the future it could also be things like 'name'
  and so on.

- Each event gets this timezone added to it: localized if it is naive.
  If it has a current timezone (non-'floating'), there is no effect.

- Unknown interaction with rrules, but current tests imply that this
  does work.  If not, it can be fixed later.

- Review: anyone with ics knowledge could take a look.  Also make sure
  that this doesn't break any other current semantics (though not
  specifying it should change nothing).
