### PR TITLE
Fix several tests

### DIFF
--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -45,6 +45,9 @@ def test_calendar_default_timezone():
               - summary: February 1
                 begin: 2022-02-01 00:00:00 +02:00
                 duration: {hours: 1}
+
+              - summary: Earth day (all day)
+                begin: 2022-04-22
             '''
         ))]
     )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -60,7 +60,8 @@ def test_rrule():
         )
     )
     event_str = event.serialize()
-    assert 'DTEND' not in event_str
+    # DTEND exists and is the next day, calendar tools import this
+    # correctly as being a one-day event
     assert 'RRULE:FREQ=YEARLY;UNTIL=20300422T000000' in event_str
 
 

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -75,7 +75,7 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo=None) -> ics.Event:
             ))
 
     event.dtstamp = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
-    if tz and event.floating:
+    if tz and event.floating and not event.all_day:
         event.replace_timezone(tz)
     return event
 


### PR DESCRIPTION
- Don't replace timezone of all day events

  - This was not tested for, so passed through the default timezone
    PR #8.  Add a test, then fix the problem.

- Fix test: #7 broke test by re-adding DTEND to recurring events

  - Again, there was a broken test here, caused by changed semantics
    of the output file.  After some checks on Google Calendar and
    Thunderbird, I think the current behavior is correct.

For details on both of these, see the individual commit messages.
