### PR TITLE
Add missing interval to RRULE

### DIFF
--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -95,3 +95,25 @@ def test_calendar_name():
     cal_str = cal.serialize()
     assert "NAME:My Second Calendar" in cal_str
     assert cal_str.count("NAME:") == 1
+
+
+def test_repeat():
+    cal = files_to_calendar(
+        [
+            iowrap(
+                """
+            events:
+                - summary: Repeating Event
+                  begin: 2022-02-11
+                  repeat:
+                    interval:
+                      days: 5
+                    until: 2022-02-21
+            """
+            )
+        ]
+    )
+    cal_str = cal.serialize()
+    rrule = [line for line in cal_str.split("\n") if line.startswith("RRULE")][0]
+    assert "FREQ=DAILY" in rrule
+    assert "INTERVAL=5" in rrule

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -66,6 +66,7 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
 
         rrule = dateutil.rrule.rrule(
             freq=interval_type[interval_measure],
+            interval=interval[interval_measure],
             until=repeat.get("until"),
             dtstart=d["begin"],
         )


### PR DESCRIPTION
Otherwise, entries can only repeat daily, yearly, etc. instead of
every X days/years/etc.

@melissawm This should address the issue you've been seeing.  Once this is merged, we should also re-pin on the scientific-python.org website.