### PR TITLE
Remove requirements.txt, add github URL directly to pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,13 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install flit
         flit install
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ Features include:
 pip install yaml2ics
 ```
 
-**Note:** due to a pending release of a dependency (`ics-py`), an additional
-step is required:
-
-```
-pip install -r requirements.txt
-```
-
 ## Usage
 
 To produce a calendar from a list of events:
@@ -73,7 +66,6 @@ To install the development version, fork the source of the project and make an
 editable install:
 
 ```
-pip install -r requirements.txt  # temporary workaround for ics-py
 pip install -e ".[test]"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dynamic = ["description"]
 
 dependencies = [
 #    "ics >=0.8",
+    "ics @ https://github.com/ics-py/ics-py/archive/refs/heads/main.zip",
     "python-dateutil",
     "pyyaml",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-https://github.com/ics-py/ics-py/archive/refs/heads/main.zip


### PR DESCRIPTION
- I found that this syntax allowed to directly specify a dependency's
  version at a URL.
- Make the other changes to remove the mention of the use of
  requirements.txt for installation
- Review:
  - I guess if it seems to work then this is fine
  - should we pin the URL to a specific version?  Personally I
    wouldn't.
