### PR TITLE
Add the possibility to skip dates for recurring events

### DIFF
--- a/example/test_calendar.yaml
+++ b/example/test_calendar.yaml
@@ -32,7 +32,18 @@ events:
         # seconds, minutes, hours, days, weeks, months, years
         weeks: 1
       until: 2022-12-31  # required
-      except_on: [2022-12-19, 2022-12-26]
+
+  - summary: Recurring event with exception
+    begin: 2022-07-01 10:00:00
+    duration: {minutes: 60}
+    repeat:
+      interval:
+        # seconds, minutes, hours, days, weeks, months, years
+        hours: 4
+      until: 2022-07-31  # required
+      except_on:
+        - 2022-07-13
+        - 2022-07-14 06:00:00
 
   # All-day event
   - summary: Earth Day

--- a/example/test_calendar.yaml
+++ b/example/test_calendar.yaml
@@ -32,6 +32,7 @@ events:
         # seconds, minutes, hours, days, weeks, months, years
         weeks: 1
       until: 2022-12-31  # required
+      except_on: [2022-12-19, 2022-12-26]
 
   # All-day event
   - summary: Earth Day

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -56,6 +56,7 @@ def test_rrule():
               interval:
                 years: 1
               until: 2030-04-22
+              except_on: [2022-04-22, 2026-04-22]
             """
         )
     )
@@ -63,7 +64,8 @@ def test_rrule():
     # DTEND exists and is the next day, calendar tools import this
     # correctly as being a one-day event
     assert "RRULE:FREQ=YEARLY;UNTIL=20300422T000000" in event_str
-
+    assert "EXDATE:20220422" in event_str
+    assert "EXDATE:20260422" in event_str
 
 def test_event_with_time_range():
     event = event_from_yaml(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -64,8 +64,7 @@ def test_rrule():
     # DTEND exists and is the next day, calendar tools import this
     # correctly as being a one-day event
     assert "RRULE:FREQ=YEARLY;UNTIL=20300422T000000" in event_str
-    assert "EXDATE:20220422" in event_str
-    assert "EXDATE:20260422" in event_str
+    assert "EXDATE:20220422,20260422" in event_str
 
 
 def test_event_with_time_range():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -56,7 +56,6 @@ def test_rrule():
               interval:
                 years: 1
               until: 2030-04-22
-              except_on: [2022-04-22, 2026-04-22]
             """
         )
     )
@@ -64,7 +63,33 @@ def test_rrule():
     # DTEND exists and is the next day, calendar tools import this
     # correctly as being a one-day event
     assert "RRULE:FREQ=YEARLY;UNTIL=20300422T000000" in event_str
-    assert "EXDATE:20220422,20260422" in event_str
+
+
+def test_exception():
+    event = event_from_yaml(
+        parse_yaml(
+            """
+            summary: Recurring event with exception
+            timezone: America/Los_Angeles
+            begin: 2022-07-01 10:00:00
+            duration: {minutes: 60}
+            repeat:
+              interval:
+                hours: 4
+              until: 2022-07-31
+              except_on:
+                - 2022-07-13
+                - 2022-07-14 06:00:00
+            """
+        )
+    )
+    event_str = event.serialize()
+    # DTEND exists and is the next day, calendar tools import this
+    # correctly as being a one-day event
+    assert (
+        "EXDATE;TZID=/ics.py/2020.1/America/Los_Angeles:20220713,20220714T060000"
+        in event_str
+    )
 
 
 def test_event_with_time_range():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -67,6 +67,7 @@ def test_rrule():
     assert "EXDATE:20220422" in event_str
     assert "EXDATE:20260422" in event_str
 
+
 def test_event_with_time_range():
     event = event_from_yaml(
         parse_yaml(

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -92,7 +92,8 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
 
         if "except_on" in repeat:
             exdate = map(
-                lambda exdate: datetime.strftime(exdate, "%Y%m%d"), repeat["except_on"]
+                lambda exdate: datetime.strftime(exdate, "%Y%m%dT%H%M%S"),
+                repeat["except_on"],
             )
             event.extra.append(
                 ics.ContentLine(

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -90,6 +90,15 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
             )
         )
 
+        if "except_on" in repeat:
+            for exdate in repeat.get("except_on"):
+                event.extra.append(
+                    ics.ContentLine(
+                        name="EXDATE",
+                        value=datetime.strftime(exdate, "%Y%m%d"),
+                    )
+                )
+
     event.dtstamp = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
     if tz and event.floating and not event.all_day:
         event.replace_timezone(tz)

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -91,13 +91,15 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
         )
 
         if "except_on" in repeat:
-            for exdate in repeat.get("except_on"):
-                event.extra.append(
-                    ics.ContentLine(
-                        name="EXDATE",
-                        value=datetime.strftime(exdate, "%Y%m%d"),
-                    )
+            exdate = map(
+                lambda exdate: datetime.strftime(exdate, "%Y%m%d"), repeat["except_on"]
+            )
+            event.extra.append(
+                ics.ContentLine(
+                    name="EXDATE",
+                    value=",".join(exdate),
                 )
+            )
 
     event.dtstamp = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
     if tz and event.floating and not event.all_day:

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -4,9 +4,9 @@ yaml2ics
 
 CLI to convert yaml into ics.
 """
+import datetime
 import os
 import sys
-from datetime import datetime, tzinfo
 
 import dateutil
 import dateutil.rrule
@@ -25,7 +25,14 @@ interval_type = {
 }
 
 
-def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
+def strfexception(exdate):
+    if isinstance(exdate, datetime.datetime):
+        return datetime.datetime.strftime(exdate, "%Y%m%dT%H%M%S")
+    elif isinstance(exdate, datetime.date):
+        return datetime.datetime.strftime(exdate, "%Y%m%d")
+
+
+def event_from_yaml(event_yaml: dict, tz: datetime.tzinfo = None) -> ics.Event:
     d = event_yaml
     repeat = d.pop("repeat", None)
     if "timezone" in d:
@@ -91,18 +98,27 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
         )
 
         if "except_on" in repeat:
-            exdate = map(
-                lambda exdate: datetime.strftime(exdate, "%Y%m%dT%H%M%S"),
+            exdates = map(
+                lambda exdate: strfexception(exdate),
                 repeat["except_on"],
             )
-            event.extra.append(
-                ics.ContentLine(
-                    name="EXDATE",
-                    value=",".join(exdate),
+            if tz:
+                event.extra.append(
+                    ics.ContentLine(
+                        name="EXDATE",
+                        params={"TZID": [str(ics.Timezone.from_tzinfo(tz))]},
+                        value=",".join(exdates),
+                    )
                 )
-            )
+            else:
+                event.extra.append(
+                    ics.ContentLine(
+                        name="EXDATE",
+                        value=",".join(exdates),
+                    )
+                )
 
-    event.dtstamp = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+    event.dtstamp = datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
     if tz and event.floating and not event.all_day:
         event.replace_timezone(tz)
     return event


### PR DESCRIPTION
Close #23 .

This PR introduces the sub-key `except_on` to exclude dates from a recurrent event.

As for now, excluding specific times is not yet supported as I struggled with getting timezones right. Maybe someone can give me a hint on how to provide the correct timezone information to the ics file? I'm happy to learn!

Signed-off-by: Eduard Itrich <eduard@itrich.net>