### PR TITLE
Add possibility to add additional dates to recurring events

### DIFF
--- a/example/test_calendar.yaml
+++ b/example/test_calendar.yaml
@@ -60,5 +60,5 @@ events:
   # Event with custom RRULE
   - summary: Another day
     begin: 2021-04-22
-    ics: |-
+    ics: |
       RRULE:FREQ=YEARLY;UNTIL=20280422T000000

--- a/example/test_calendar.yaml
+++ b/example/test_calendar.yaml
@@ -33,7 +33,7 @@ events:
         weeks: 1
       until: 2022-12-31 # required
 
-  - summary: Recurring event with exception
+  - summary: Recurring event with exception and additional date
     begin: 2022-07-01 10:00:00
     duration: { minutes: 60 }
     repeat:
@@ -44,6 +44,8 @@ events:
       except_on:
         - 2022-07-13
         - 2022-07-14 06:00:00
+      also_on:
+        - 2022-12-24 06:00:00
 
   # All-day event
   - summary: Earth Day

--- a/example/test_calendar.yaml
+++ b/example/test_calendar.yaml
@@ -58,5 +58,5 @@ events:
   # Event with custom RRULE
   - summary: Another day
     begin: 2021-04-22
-    ics: |
+    ics: |-
       RRULE:FREQ=YEARLY;UNTIL=20280422T000000

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -69,7 +69,7 @@ def test_exception():
     event = event_from_yaml(
         parse_yaml(
             """
-            summary: Recurring event with exception
+            summary: Recurring event with exception and additional date
             timezone: America/Los_Angeles
             begin: 2022-07-01 10:00:00
             duration: {minutes: 60}
@@ -80,6 +80,8 @@ def test_exception():
               except_on:
                 - 2022-07-13
                 - 2022-07-14 06:00:00
+              also_on:
+                - 2022-12-24 06:00:00
             """
         )
     )
@@ -90,6 +92,7 @@ def test_exception():
         "EXDATE;TZID=/ics.py/2020.1/America/Los_Angeles:20220713,20220714T060000"
         in event_str
     )
+    assert "RDATE;TZID=/ics.py/2020.1/America/Los_Angeles:20221224T060000" in event_str
 
 
 def test_event_with_time_range():

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -38,21 +38,13 @@ def datetime2utc(date):
 def add_recurrence_property(
     event: ics.Event, property_name, dates: map, tz: datetime.tzinfo = None
 ):
-    if tz:
-        event.extra.append(
-            ics.ContentLine(
-                name=property_name,
-                params={"TZID": [str(ics.Timezone.from_tzinfo(tz))]},
-                value=",".join(dates),
-            )
+    event.extra.append(
+        ics.ContentLine(
+            name=property_name,
+            params={"TZID": [str(ics.Timezone.from_tzinfo(tz))]} if tz else None,
+            value=",".join(dates),
         )
-    else:
-        event.extra.append(
-            ics.ContentLine(
-                name=property_name,
-                value=",".join(dates),
-            )
-        )
+    )
 
 
 def event_from_yaml(event_yaml: dict, tz: datetime.tzinfo = None) -> ics.Event:
@@ -123,17 +115,11 @@ def event_from_yaml(event_yaml: dict, tz: datetime.tzinfo = None) -> ics.Event:
         )
 
         if "except_on" in repeat:
-            exdates = map(
-                lambda exdate: datetime2utc(exdate),
-                repeat["except_on"],
-            )
+            exdates = [datetime2utc(rdate) for rdate in repeat["except_on"]]
             add_recurrence_property(event, "EXDATE", exdates, tz)
 
         if "also_on" in repeat:
-            rdates = map(
-                lambda rdate: datetime2utc(rdate),
-                repeat["also_on"],
-            )
+            rdates = [datetime2utc(rdate) for rdate in repeat["also_on"]]
             add_recurrence_property(event, "RDATE", rdates, tz)
 
     event.dtstamp = datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)


### PR DESCRIPTION
This PR is related to #23. By adding `also_on` to the `repeat` property, further dates can be added to a recurring event.

This can be nicely combined with `except_on` in order to postpone a recurring event only within a specific week, e.g.:

```
  - summary: Monday meeting
    begin: 2022-12-05 10:00:00
    duration: { minutes: 60 }
    repeat:
      interval:
        weeks:1
      until: 2022-12-31
      except_on:
        - 2022-12-26 # Skip the second day of christmas...
      also_on:
        - 2022-12-28 10:00:00 # ...and meet on Wednesday instead
```

Kudos to @garloff for bringing up this idea! This feature saves us a lot of copy & paste work if we have to exceptionally reschedule a recurring event.