### PR TITLE
Print concise error messages when invoking `yaml2ics` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ test = ["pytest >= 7.3", "pytest-cov >= 4.0"]
 lint = ["pre-commit >= 3.0"]
 
 [project.scripts]
-yaml2ics = "yaml2ics:main"
+yaml2ics = "yaml2ics:cli"
 
 [project.urls]
 Home = "https://github.com/scientific-python/yaml2ics"

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -186,6 +186,9 @@ def files_to_calendar(files: list) -> ics.Calendar:
     return calendar
 
 
+# `main` is separate from `cli` to facilitate testing.
+# The only difference being that `main` raises errors while
+# `cli` prints them and exits with errorcode 1
 def main():
     if len(sys.argv) < 2:
         raise RuntimeError("Usage: yaml2ics.py FILE1.yaml FILE2.yaml ...")
@@ -200,9 +203,13 @@ def main():
     print(calendar.serialize())
 
 
-if __name__ == "__main__":  # pragma: no cover
+def cli():
     try:
         main()
     except Exception as e:
         print(e, file=sys.stderr)
         sys.exit(-1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()


### PR DESCRIPTION
This suppresses the traceback currently printed when running `yaml2ics`.