### PR TITLE
Fix date exclusion

### DIFF
--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -112,6 +112,30 @@ def test_calendar_event_different_timezone():
     assert "DTSTART:20220131T220000Z"  # 1 feb
 
 
+def test_calendar_no_timezone():
+    """We default to UTC if no timezone is given."""
+    cal = files_to_calendar(
+        [
+            iowrap(
+                """
+            events:
+              - summary: Some new year's days
+                begin: 2022-01-01
+                repeat:
+                  interval:
+                    years: 1
+                  until: 2030-01-01
+                  except_on:
+                    - 2023-01-01
+            """
+            )
+        ]
+    )
+    cal_str = cal.serialize()
+    assert cal_str.startswith("BEGIN:VCALENDAR")
+    assert "UTC" in cal_str
+
+
 def test_calendar_name():
     cal = files_to_calendar(
         [

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -86,10 +86,13 @@ def test_exception():
         )
     )
     event_str = event.serialize()
+    # Handle line overflow
+    event_str = event_str.replace(" ", "").replace("\n", "").replace("\r", "")
+
     # DTEND exists and is the next day, calendar tools import this
     # correctly as being a one-day event
     assert (
-        "EXDATE;TZID=/ics.py/2020.1/America/Los_Angeles:20220713,20220714T060000"
+        "EXDATE;TZID=/ics.py/2020.1/America/Los_Angeles:20220713T000000,20220714T060000"
         in event_str
     )
     assert "RDATE;TZID=/ics.py/2020.1/America/Los_Angeles:20221224T060000" in event_str

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -29,7 +29,9 @@ def datetime2utc(date):
     if isinstance(date, datetime.datetime):
         return datetime.datetime.strftime(date, "%Y%m%dT%H%M%S")
     elif isinstance(date, datetime.date):
-        return datetime.datetime.strftime(date, "%Y%m%d")
+        return datetime.datetime.strftime(date, "%Y%m%dT000000")
+    else:
+        raise RuntimeError(f"Unsure how to convert {date} to UTC")
 
 
 # See RFC2445, 4.8.5 REcurrence Component Properties

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -156,9 +156,11 @@ def files_to_events(files: list) -> (ics.Calendar, str):
             calendar_yaml = yaml.load(f.read(), Loader=yaml.FullLoader)
         else:
             calendar_yaml = yaml.load(open(f), Loader=yaml.FullLoader)
-        tz = calendar_yaml.get("timezone", None)
+        tz = calendar_yaml.get("timezone")
         if tz is not None:
             tz = gettz(tz)
+        else:
+            tz = dateutil.tz.UTC
         if "include" in calendar_yaml:
             included_events, _name = files_to_events(
                 os.path.join(os.path.dirname(f), newfile)


### PR DESCRIPTION
This is an attempt at resolving #51 and #54.

1. `except_on` and `also_on` failed to work on calendars without timezones. Now, calendars default to UTC if no timezone is specified.
2. According to #51, adding a timestamp to `except_on` should make it work. This PR does that, but it doesn't work yet.

/cc @itrich 