### PR TITLE
Process existing ics files from URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "ics == 0.8.0.dev0",
     "python-dateutil >= 2.8",
     "pyyaml >= 6",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -169,7 +169,7 @@ def files_to_events(files: list) -> (ics.Calendar, str, bool):
         if tz is not None:
             tz = gettz(tz)
         if "include" in calendar_yaml:
-            included_events, _name = files_to_events(
+            included_events, _name, _ = files_to_events(
                 os.path.join(os.path.dirname(f), newfile)
                 for newfile in calendar_yaml["include"]
             )

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -11,8 +11,8 @@ import sys
 import dateutil
 import dateutil.rrule
 import ics
-import yaml
 import requests
+import yaml
 from dateutil.tz import gettz
 
 interval_type = {
@@ -198,6 +198,7 @@ def files_to_calendar(files: list) -> ics.Calendar:
             calendar.extra.append(ics.ContentLine(name="X-WR-CALNAME", value=name))
 
     return calendar
+
 
 # `main` is separate from `cli` to facilitate testing.
 # The only difference being that `main` raises errors while


### PR DESCRIPTION
This PR adds functionality to process existing .ics files from a URL and create a compatible calendar. (The goal of this PR is to be able to show the result in scientific-python.org)

Addresses https://github.com/scientific-python/scientific-python.org/issues/246

Feedback is welcome!