### PR TITLE
Unpin pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest == 7.4.4", "pytest-cov == 4.1.0"]
+test = ["pytest >= 7.4.4", "pytest-cov >= 4.1.0"]
 lint = ["pre-commit == 3.6.0"]
 dev = ["changelist == 0.4"]
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,6 @@
-from util import parse_yaml
-
 from yaml2ics import event_from_yaml
+
+from .util import parse_yaml
 
 
 def test_basic_structure():

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -32,6 +32,14 @@ def datetime2utc(date):
         return datetime.datetime.strftime(date, "%Y%m%d")
 
 
+def utcnow():
+    try:
+        return datetime.datetime.now(datetime.UTC).replace(tzinfo=dateutil.tz.UTC)
+    except AttributeError:
+        # This section can be removed once Python 3.11 is the minimum version
+        return datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+
+
 # See RFC2445, 4.8.5 REcurrence Component Properties
 # This function can be used to add a list of e.g. exception dates (EXDATE) or
 # recurrence dates (RDATE) to a reoccurring event
@@ -120,7 +128,7 @@ def event_from_yaml(event_yaml: dict, tz: datetime.tzinfo = None) -> ics.Event:
             rdates = [datetime2utc(rdate) for rdate in repeat["also_on"]]
             add_recurrence_property(event, "RDATE", rdates, tz)
 
-    event.dtstamp = datetime.datetime.now(datetime.UTC).replace(tzinfo=dateutil.tz.UTC)
+    event.dtstamp = utcnow()
     if tz and event.floating and not event.all_day:
         event.replace_timezone(tz)
 

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -120,7 +120,7 @@ def event_from_yaml(event_yaml: dict, tz: datetime.tzinfo = None) -> ics.Event:
             rdates = [datetime2utc(rdate) for rdate in repeat["also_on"]]
             add_recurrence_property(event, "RDATE", rdates, tz)
 
-    event.dtstamp = datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+    event.dtstamp = datetime.datetime.now(datetime.UTC).replace(tzinfo=dateutil.tz.UTC)
     if tz and event.floating and not event.all_day:
         event.replace_timezone(tz)
 

--- a/yaml2ics.py
+++ b/yaml2ics.py
@@ -36,7 +36,7 @@ def utcnow():
     try:
         return datetime.datetime.now(datetime.UTC).replace(tzinfo=dateutil.tz.UTC)
     except AttributeError:
-        # This section can be removed once Python 3.11 is the minimum version
+        # TODO: This section can be removed once Python 3.11 is the minimum version
         return datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
 
 


### PR DESCRIPTION
xref: https://github.com/pytest-dev/pytest/issues/9567#issuecomment-1905792017

Also replaced `datetime.utcnow()` to avoid deprecation warning.